### PR TITLE
Add user_id to authentication response

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,3 +25,7 @@ services:
       $processor: '@api_platform.doctrine.orm.state.persist_processor'
   # add more service definitions when explicit configuration is needed
   # please note that last definitions always *replace* previous ones
+
+  App\EventListener\AuthenticationSuccessListener:
+    tags:
+      - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: onAuthenticationSuccessResponse }

--- a/deploy.php
+++ b/deploy.php
@@ -9,7 +9,7 @@ require 'recipe/symfony.php';
 set('repository', 'git@github.com:AurelienLab/daps-p7-bilemo.git');
 
 add('shared_files', []);
-add('shared_dirs', []);
+add('shared_dirs', ['config/jwt']);
 add('writable_dirs', []);
 
 // Hosts

--- a/src/EventListener/AuthenticationSuccessListener.php
+++ b/src/EventListener/AuthenticationSuccessListener.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\EventListener;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class AuthenticationSuccessListener
+{
+
+
+    public function onAuthenticationSuccessResponse(AuthenticationSuccessEvent $event)
+    {
+        $data = $event->getData();
+        $user = $event->getUser();
+
+        if (!$user instanceof UserInterface) {
+            return;
+        }
+
+        $data['user_id'] = $user->getId();
+
+        $event->setData($data);
+    }
+
+
+}


### PR DESCRIPTION
Allow a user to know its id for future requests on `/customers` endpoints